### PR TITLE
Prevent exception when query object has empty WHERE clause

### DIFF
--- a/tagging/models.py
+++ b/tagging/models.py
@@ -93,6 +93,7 @@ class TagManager(models.Manager):
         if min_count is not None:
             counts = True
 
+        params = params or []
         model_table = qn(model._meta.db_table)
         model_pk = '%s.%s' % (model_table, qn(model._meta.pk.column))
         query = """

--- a/tagging/models.py
+++ b/tagging/models.py
@@ -177,10 +177,11 @@ class TagManager(models.Manager):
         Passing a value for ``min_count`` implies ``counts=True``.
         """
         compiler = queryset.query.get_compiler(using=queryset.db)
-        where, params = compiler.compile(queryset.query.where)
+        params = None
         extra_joins = ' '.join(compiler.get_from_clause()[0][1:])
 
-        if where:
+        if len(queryset.query.where):
+            where, params = compiler.compile(queryset.query.where)
             extra_criteria = 'AND %s' % where
         else:
             extra_criteria = ''


### PR DESCRIPTION
Hi there 👋 

I discovered your fork of the `django-tagging` project from the discussion on [this PR](https://github.com/Fantomas42/django-tagging/pull/23). I'm trying to use this in a project which runs on Django 4, and made some small fixes which I've included in this PR.

This PR modifies the `get_usage_for_queryset()` method to handle empty WHERE-clauses in the passed-in query.

Let me know if you'd like any additional info!